### PR TITLE
Implement admin dashboard with key metrics (#14)

### DIFF
--- a/.claude/tasks/issue-14-admin-dashboard.md
+++ b/.claude/tasks/issue-14-admin-dashboard.md
@@ -1,0 +1,14 @@
+# Task: Admin Dashboard with Key Metrics (#14)
+
+- [x] Create RecentGradeActivity DTO
+- [x] Create RecentAbsenceActivity DTO
+- [x] Create DashboardResponse DTO
+- [x] Add recent grades JPQL query to GradeRepository
+- [x] Add recent absences JPQL query to AbsenceRepository
+- [x] Create DashboardService
+- [x] Create DashboardController (secured ADMIN-only)
+- [x] Create dashboard types (frontend)
+- [x] Create dashboard API function (frontend)
+- [x] Create useDashboard hook (frontend)
+- [x] Update AdminDashboardPage with metrics UI
+- [x] Update AdminDashboardPage styles

--- a/gradebook-backend/src/main/java/application/gradebookbackend/controller/DashboardController.java
+++ b/gradebook-backend/src/main/java/application/gradebookbackend/controller/DashboardController.java
@@ -1,0 +1,25 @@
+package application.gradebookbackend.controller;
+
+import application.gradebookbackend.dto.DashboardResponse;
+import application.gradebookbackend.service.DashboardService;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin/dashboard")
+public class DashboardController {
+
+    private final DashboardService dashboardService;
+
+    public DashboardController(DashboardService dashboardService) {
+        this.dashboardService = dashboardService;
+    }
+
+    @GetMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public DashboardResponse getDashboardStats() {
+        return dashboardService.getDashboardStats();
+    }
+}

--- a/gradebook-backend/src/main/java/application/gradebookbackend/dto/DashboardResponse.java
+++ b/gradebook-backend/src/main/java/application/gradebookbackend/dto/DashboardResponse.java
@@ -1,0 +1,10 @@
+package application.gradebookbackend.dto;
+
+import java.util.List;
+
+public record DashboardResponse(
+        long totalStudents,
+        long totalParents,
+        List<RecentGradeActivity> recentGrades,
+        List<RecentAbsenceActivity> recentAbsences
+) {}

--- a/gradebook-backend/src/main/java/application/gradebookbackend/dto/RecentAbsenceActivity.java
+++ b/gradebook-backend/src/main/java/application/gradebookbackend/dto/RecentAbsenceActivity.java
@@ -1,0 +1,14 @@
+package application.gradebookbackend.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record RecentAbsenceActivity(
+        UUID absenceId,
+        LocalDate date,
+        String reason,
+        UUID studentId,
+        String studentName,
+        LocalDateTime createdAt
+) {}

--- a/gradebook-backend/src/main/java/application/gradebookbackend/dto/RecentGradeActivity.java
+++ b/gradebook-backend/src/main/java/application/gradebookbackend/dto/RecentGradeActivity.java
@@ -1,0 +1,16 @@
+package application.gradebookbackend.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record RecentGradeActivity(
+        UUID gradeId,
+        String subject,
+        BigDecimal value,
+        LocalDate date,
+        UUID studentId,
+        String studentName,
+        LocalDateTime createdAt
+) {}

--- a/gradebook-backend/src/main/java/application/gradebookbackend/repository/AbsenceRepository.java
+++ b/gradebook-backend/src/main/java/application/gradebookbackend/repository/AbsenceRepository.java
@@ -1,11 +1,16 @@
 package application.gradebookbackend.repository;
 
 import application.gradebookbackend.domain.Absence;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.UUID;
 
 public interface AbsenceRepository extends JpaRepository<Absence, UUID> {
     List<Absence> findByStudentIdOrderByDateDesc(UUID studentId);
+
+    @Query("SELECT a FROM Absence a JOIN FETCH a.student s JOIN FETCH s.user ORDER BY a.createdAt DESC")
+    List<Absence> findRecentAbsencesWithStudent(Pageable pageable);
 }

--- a/gradebook-backend/src/main/java/application/gradebookbackend/repository/GradeRepository.java
+++ b/gradebook-backend/src/main/java/application/gradebookbackend/repository/GradeRepository.java
@@ -1,10 +1,18 @@
 package application.gradebookbackend.repository;
 
 import application.gradebookbackend.domain.Grade;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 import java.util.UUID;
 
 @Repository
 public interface GradeRepository extends JpaRepository<Grade, UUID> {
+
+    @Query("SELECT g.id, g.subject, g.value, g.date, g.createdAt, s.id, s.user.firstName, s.user.lastName " +
+           "FROM Student s JOIN s.grades g ORDER BY g.createdAt DESC")
+    List<Object[]> findRecentGradesWithStudentInfo(Pageable pageable);
 }

--- a/gradebook-backend/src/main/java/application/gradebookbackend/service/DashboardService.java
+++ b/gradebook-backend/src/main/java/application/gradebookbackend/service/DashboardService.java
@@ -1,0 +1,72 @@
+package application.gradebookbackend.service;
+
+import application.gradebookbackend.domain.Absence;
+import application.gradebookbackend.domain.Subject;
+import application.gradebookbackend.dto.DashboardResponse;
+import application.gradebookbackend.dto.RecentAbsenceActivity;
+import application.gradebookbackend.dto.RecentGradeActivity;
+import application.gradebookbackend.repository.AbsenceRepository;
+import application.gradebookbackend.repository.GradeRepository;
+import application.gradebookbackend.repository.ParentRepository;
+import application.gradebookbackend.repository.StudentRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class DashboardService {
+
+    private final StudentRepository studentRepository;
+    private final ParentRepository parentRepository;
+    private final GradeRepository gradeRepository;
+    private final AbsenceRepository absenceRepository;
+
+    public DashboardService(StudentRepository studentRepository,
+                            ParentRepository parentRepository,
+                            GradeRepository gradeRepository,
+                            AbsenceRepository absenceRepository) {
+        this.studentRepository = studentRepository;
+        this.parentRepository = parentRepository;
+        this.gradeRepository = gradeRepository;
+        this.absenceRepository = absenceRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public DashboardResponse getDashboardStats() {
+        long totalStudents = studentRepository.count();
+        long totalParents = parentRepository.count();
+
+        List<Object[]> gradeRows = gradeRepository.findRecentGradesWithStudentInfo(PageRequest.of(0, 3));
+        List<RecentGradeActivity> recentGrades = gradeRows.stream()
+                .map(row -> new RecentGradeActivity(
+                        (UUID) row[0],
+                        ((Subject) row[1]).name(),
+                        (BigDecimal) row[2],
+                        (LocalDate) row[3],
+                        (UUID) row[5],
+                        row[6] + " " + row[7],
+                        (LocalDateTime) row[4]
+                ))
+                .toList();
+
+        List<Absence> recentAbsenceEntities = absenceRepository.findRecentAbsencesWithStudent(PageRequest.of(0, 3));
+        List<RecentAbsenceActivity> recentAbsences = recentAbsenceEntities.stream()
+                .map(a -> new RecentAbsenceActivity(
+                        a.getId(),
+                        a.getDate(),
+                        a.getReason(),
+                        a.getStudent().getId(),
+                        a.getStudent().getUser().getFirstName() + " " + a.getStudent().getUser().getLastName(),
+                        a.getCreatedAt()
+                ))
+                .toList();
+
+        return new DashboardResponse(totalStudents, totalParents, recentGrades, recentAbsences);
+    }
+}

--- a/gradebook-frontend/src/features/dashboard/api/dashboard.api.ts
+++ b/gradebook-frontend/src/features/dashboard/api/dashboard.api.ts
@@ -1,0 +1,7 @@
+import axiosClient from '@/api/axiosClient'
+import type { DashboardResponse } from '../types/dashboard.types'
+
+export const getDashboardStats = async (): Promise<DashboardResponse> => {
+  const { data } = await axiosClient.get<DashboardResponse>('/admin/dashboard')
+  return data
+}

--- a/gradebook-frontend/src/features/dashboard/hooks/useDashboard.ts
+++ b/gradebook-frontend/src/features/dashboard/hooks/useDashboard.ts
@@ -1,0 +1,8 @@
+import { useQuery } from '@tanstack/react-query'
+import { getDashboardStats } from '../api/dashboard.api'
+
+export const useDashboard = () =>
+  useQuery({
+    queryKey: ['dashboard'],
+    queryFn: getDashboardStats,
+  })

--- a/gradebook-frontend/src/features/dashboard/types/dashboard.types.ts
+++ b/gradebook-frontend/src/features/dashboard/types/dashboard.types.ts
@@ -1,0 +1,25 @@
+export interface RecentGradeActivity {
+  gradeId: string
+  subject: string
+  value: number
+  date: string
+  studentId: string
+  studentName: string
+  createdAt: string
+}
+
+export interface RecentAbsenceActivity {
+  absenceId: string
+  date: string
+  reason?: string
+  studentId: string
+  studentName: string
+  createdAt: string
+}
+
+export interface DashboardResponse {
+  totalStudents: number
+  totalParents: number
+  recentGrades: RecentGradeActivity[]
+  recentAbsences: RecentAbsenceActivity[]
+}

--- a/gradebook-frontend/src/pages/AdminDashboardPage/AdminDashboardPage.module.scss
+++ b/gradebook-frontend/src/pages/AdminDashboardPage/AdminDashboardPage.module.scss
@@ -2,5 +2,161 @@
   padding: 32px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 24px;
+  max-width: 900px;
+}
+
+.loadingWrapper {
+  display: flex;
+  justify-content: center;
+  padding: 64px;
+}
+
+// --- Stat cards ---
+
+.statsRow {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.statCard {
+  background: $color-surface;
+  border: 1px solid $color-border;
+  border-radius: $radius-lg;
+  box-shadow: $shadow-card;
+  padding: 20px 24px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  min-width: 180px;
+  flex: 1;
+}
+
+.statIcon {
+  width: 48px;
+  height: 48px;
+  border-radius: $radius-md;
+  background: rgba(21, 101, 192, 0.1);
+  color: $color-primary;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+
+  svg {
+    font-size: 24px;
+  }
+}
+
+.statValue {
+  font-size: 28px;
+  font-weight: 700;
+  color: $color-text-primary;
+  line-height: 1;
+}
+
+.statLabel {
+  font-size: 13px;
+  color: $color-text-secondary;
+  margin-top: 4px;
+}
+
+// --- Activity cards ---
+
+.activityRow {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  align-items: flex-start;
+}
+
+.activityCard {
+  background: $color-surface;
+  border: 1px solid $color-border;
+  border-radius: $radius-lg;
+  box-shadow: $shadow-card;
+  padding: 20px 24px;
+  flex: 1;
+  min-width: 260px;
+}
+
+.activityTitle {
+  font-size: 15px;
+  font-weight: 600;
+  color: $color-text-primary;
+  margin-bottom: 16px;
+}
+
+.activityList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.activityItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 0;
+  border-bottom: 1px solid $color-border;
+
+  &:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+  }
+
+  &:first-child {
+    padding-top: 0;
+  }
+}
+
+.activityMain {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.activityStudent {
+  font-size: 14px;
+  font-weight: 600;
+  color: $color-text-primary;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.activityMeta {
+  font-size: 12px;
+  color: $color-text-secondary;
+}
+
+.activityRight {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.gradeValue {
+  font-size: 16px;
+  font-weight: 700;
+  color: $color-primary;
+}
+
+.activityDate {
+  font-size: 12px;
+  color: $color-text-secondary;
+}
+
+.empty {
+  font-size: 13px;
+  color: $color-text-secondary;
+  padding: 12px 0;
 }

--- a/gradebook-frontend/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
+++ b/gradebook-frontend/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
@@ -1,7 +1,20 @@
-import { Typography } from '@mui/material'
+import { CircularProgress, Typography } from '@mui/material'
+import PeopleAltIcon from '@mui/icons-material/PeopleAlt'
+import SchoolIcon from '@mui/icons-material/School'
+import { useDashboard } from '@/features/dashboard/hooks/useDashboard'
 import styles from './AdminDashboardPage.module.scss'
 
+const SUBJECT_LABELS: Record<string, string> = {
+  BULGARIAN: 'Български език',
+  LITERATURE: 'Литература',
+}
+
+const formatDate = (iso: string) =>
+  new Date(iso).toLocaleDateString('bg-BG', { day: '2-digit', month: '2-digit', year: 'numeric' })
+
 export const AdminDashboardPage = () => {
+  const { data, isLoading } = useDashboard()
+
   return (
     <div className={styles.page}>
       <Typography variant="h5" sx={{ fontWeight: 600 }}>
@@ -10,6 +23,85 @@ export const AdminDashboardPage = () => {
       <Typography variant="body2" color="text.secondary">
         Добре дошли в административния панел на Дневника.
       </Typography>
+
+      {isLoading ? (
+        <div className={styles.loadingWrapper}>
+          <CircularProgress />
+        </div>
+      ) : data ? (
+        <>
+          <div className={styles.statsRow}>
+            <div className={styles.statCard}>
+              <div className={styles.statIcon}>
+                <SchoolIcon />
+              </div>
+              <div>
+                <div className={styles.statValue}>{data.totalStudents}</div>
+                <div className={styles.statLabel}>Ученици</div>
+              </div>
+            </div>
+
+            <div className={styles.statCard}>
+              <div className={styles.statIcon}>
+                <PeopleAltIcon />
+              </div>
+              <div>
+                <div className={styles.statValue}>{data.totalParents}</div>
+                <div className={styles.statLabel}>Родители</div>
+              </div>
+            </div>
+          </div>
+
+          <div className={styles.activityRow}>
+            <div className={styles.activityCard}>
+              <div className={styles.activityTitle}>Последни оценки</div>
+              {data.recentGrades.length === 0 ? (
+                <div className={styles.empty}>Няма записани оценки.</div>
+              ) : (
+                <ul className={styles.activityList}>
+                  {data.recentGrades.map((g) => (
+                    <li key={g.gradeId} className={styles.activityItem}>
+                      <div className={styles.activityMain}>
+                        <span className={styles.activityStudent}>{g.studentName}</span>
+                        <span className={styles.activityMeta}>
+                          {SUBJECT_LABELS[g.subject] ?? g.subject}
+                        </span>
+                      </div>
+                      <div className={styles.activityRight}>
+                        <span className={styles.gradeValue}>{g.value}</span>
+                        <span className={styles.activityDate}>{formatDate(g.date)}</span>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+
+            <div className={styles.activityCard}>
+              <div className={styles.activityTitle}>Последни отсъствия</div>
+              {data.recentAbsences.length === 0 ? (
+                <div className={styles.empty}>Няма записани отсъствия.</div>
+              ) : (
+                <ul className={styles.activityList}>
+                  {data.recentAbsences.map((a) => (
+                    <li key={a.absenceId} className={styles.activityItem}>
+                      <div className={styles.activityMain}>
+                        <span className={styles.activityStudent}>{a.studentName}</span>
+                        {a.reason && (
+                          <span className={styles.activityMeta}>{a.reason}</span>
+                        )}
+                      </div>
+                      <div className={styles.activityRight}>
+                        <span className={styles.activityDate}>{formatDate(a.date)}</span>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+        </>
+      ) : null}
     </div>
   )
 }


### PR DESCRIPTION
Adds GET /admin/dashboard endpoint (ADMIN-only) returning total student/parent counts and the 3 most recent grades and absences with student names. Frontend renders stat cards and recent activity panels on the Табло page.